### PR TITLE
Update CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: Deploy
 
 on:
   push:
@@ -6,30 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build backend image
-        run: docker build -t inventory-api ./api
-      - name: Build frontend image
-        env:
-          VITE_API_BASE_URL: /api
-          VITE_MSAL_CLIENT_ID: ${{ secrets.VITE_MSAL_CLIENT_ID }}
-          VITE_MSAL_TENANT_ID: ${{ secrets.VITE_MSAL_TENANT_ID }}
-          VITE_MSAL_REDIRECT_URI: ${{ secrets.VITE_MSAL_REDIRECT_URI }}
-        run: |
-          docker build \
-            --build-arg VITE_API_BASE_URL="$VITE_API_BASE_URL" \
-            --build-arg VITE_MSAL_CLIENT_ID="$VITE_MSAL_CLIENT_ID" \
-            --build-arg VITE_MSAL_TENANT_ID="$VITE_MSAL_TENANT_ID" \
-            --build-arg VITE_MSAL_REDIRECT_URI="$VITE_MSAL_REDIRECT_URI" \
-            -t inventory-frontend ./front-end
-
   deploy:
-    needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3
@@ -39,7 +21,6 @@ jobs:
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ secrets.DEPLOY_PORT }}
           script: |
-            set -e
             cd ${{ secrets.DEPLOY_PATH }}
-            git pull
+            git pull --ff-only
             docker compose -f docker-compose.yaml up -d --build

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -60,6 +60,7 @@ Notes:
 - The MySQL schema is loaded from `api/db/schema.sql` on first boot.
 - Set strong passwords before production.
 - If Docker Desktop ignores the host binding, set `HOST_IP=0.0.0.0` and rely on Windows Firewall for access control.
+- For Docker Compose, only the root `.env` is required. Use `api/.env` and `front-end/.env` only for local (non-Docker) development.
 
 ## 4) Frontend Virtual Host (sgi-inventory.local)
 
@@ -122,7 +123,7 @@ If the user already exists, the script exits with a non-zero code, so only run i
 
 ## 10) GitHub CI/CD Workflow
 
-The workflow file is in `.github/workflows/ci-cd.yml`. It builds both images and deploys via SSH on every push to `main`.
+The workflow file is in `.github/workflows/ci-cd.yml`. It deploys via SSH on every push to `main`.
 
 ### Required GitHub Secrets
 
@@ -149,7 +150,35 @@ VITE_MSAL_REDIRECT_URI=
    ```
 2. Ensure `/home/<wsl-user>/inventory` is a git clone with the correct remote.
 3. Create and keep the `.env` file on the server (the workflow does not overwrite it).
-4. Add the deploy key to `/home/<wsl-user>/.ssh/authorized_keys`.
+4. Create a dedicated SSH key for GitHub Actions (in WSL):
+   ```bash
+   ssh-keygen -t ed25519 -f ~/.ssh/inventory_ci -C "inventory-ci"
+   ```
+5. Add the public key to `/home/<wsl-user>/.ssh/authorized_keys`:
+   ```bash
+   cat ~/.ssh/inventory_ci.pub >> /home/<wsl-user>/.ssh/authorized_keys
+   ```
+6. Store the private key from `~/.ssh/inventory_ci` in the GitHub secret `DEPLOY_SSH_KEY`.
+
+Note: the server still needs access to `git pull`. For private repos, configure a separate deploy key or a PAT on the server.
 
 After pushing to `main`, the workflow will `git pull` and run:
 `docker compose -f docker-compose.yaml up -d --build`.
+
+### GitHub CI/CD Setup (Step-by-Step)
+
+1. Push the repo to GitHub and ensure your default branch is `main`.
+2. Add the workflow file to the repo:
+   - Verify `.github/workflows/ci-cd.yml` exists in the repo.
+3. Add required secrets:
+   - GitHub -> Repo -> Settings -> Secrets and variables -> Actions -> New repository secret.
+   - Add all keys listed in **Required GitHub Secrets** above.
+4. Ensure the deploy host is reachable from GitHub Actions:
+   - Open port `22` (or your `DEPLOY_PORT`) in Windows Firewall for GitHub Actions IPs, or allow `0.0.0.0/0` if you accept broader access.
+   - Confirm WSL SSH is running and reachable: `ssh <ssh-user>@192.168.10.54 -p <port>`.
+5. Trigger a deployment:
+   - Push a commit to `main`, or
+   - GitHub -> Actions -> Deploy -> Run workflow.
+6. Verify on the server:
+   - `docker compose ps`
+   - `docker compose logs -f api`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mysql:
     image: mysql:8.0

--- a/front-end/nginx.conf
+++ b/front-end/nginx.conf
@@ -1,5 +1,6 @@
 server {
   listen 80;
+  listen [::]:80;
   server_name sgi-inventory.local;
 
   root /usr/share/nginx/html;
@@ -10,6 +11,8 @@ server {
   location / {
     try_files $uri /index.html;
   }
+
+  location = /api { return 301 /api/; }
 
   location /api/ {
     proxy_pass http://api:8000/;


### PR DESCRIPTION
This pull request updates the deployment workflow and related documentation for the project, focusing on simplifying the CI/CD process, clarifying deployment instructions, and improving configuration for both Docker Compose and Nginx. The main changes include removing the build step from the GitHub Actions workflow, updating deployment and SSH key setup instructions, and making minor configuration improvements.

**CI/CD Workflow and Deployment Process:**

- Simplified the GitHub Actions workflow by removing the build job; now only the deploy job runs, which pulls the latest code and rebuilds containers on the server. The workflow is now named "Deploy" and includes concurrency controls to prevent overlapping deployments. (`.github/workflows/ci-cd.yml`)
- Changed the git pull command in the deploy script to use `--ff-only` for safer, fast-forward-only updates. (`.github/workflows/ci-cd.yml`)

**Documentation Improvements:**

- Updated `DEPLOYMENT.md` to clarify that Docker Compose only requires the root `.env` file, and that `api/.env` and `front-end/.env` are only needed for local development.
- Expanded and clarified the GitHub CI/CD setup instructions, including step-by-step SSH key generation for GitHub Actions, proper secret configuration, and deployment verification steps. [[1]](diffhunk://#diff-04615394c116398fb5fcb0aa2d880df854202e4c94907dc81cd2647101ad3306L125-R126) [[2]](diffhunk://#diff-04615394c116398fb5fcb0aa2d880df854202e4c94907dc81cd2647101ad3306L152-R184)

**Configuration Updates:**

- Improved Nginx configuration to listen on both IPv4 and IPv6, and added a redirect for `/api` to `/api/` for better API routing. (`front-end/nginx.conf`) [[1]](diffhunk://#diff-9c6408637dd63c567da063ff3b168ff992575b1b16d4877c46a99e717ea49782R3) [[2]](diffhunk://#diff-9c6408637dd63c567da063ff3b168ff992575b1b16d4877c46a99e717ea49782R15-R16)
- Removed redundant `version` field from `docker-compose.yaml` for compatibility with newer Compose versions. (`docker-compose.yaml`)