### PR TITLE
v.1.0 dev

### DIFF
--- a/api/app/routers/category_route.py
+++ b/api/app/routers/category_route.py
@@ -92,7 +92,8 @@ def get_category(
         )
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
 
-@router.post("/", response_model=Category, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=Category, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=Category, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_category(
     category_data: CategoryCreate,
     current_user: UserRole = Depends(require_role(UserRole.ADMIN, UserRole.STAFF))

--- a/api/app/routers/issue_item_route.py
+++ b/api/app/routers/issue_item_route.py
@@ -113,7 +113,8 @@ def get_issue_item(
         )
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal Server Error")
 
-@router.post("/", response_model=IssueItemResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=IssueItemResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=IssueItemResponse, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_issue_item(
     issue_item_data: IssueItemCreate,
     current_user: dict = Depends(require_role(UserRole.ADMIN, UserRole.STAFF))

--- a/api/app/routers/issue_route.py
+++ b/api/app/routers/issue_route.py
@@ -225,7 +225,8 @@ def get_issue_items_detailed(
     """
     return get_issue_items_details(issue_id, current_user)
 
-@router.post("/", response_model=IssueResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=IssueResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=IssueResponse, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_issue(
     issue_data: IssueCreate,
     current_user: dict = Depends(require_role(UserRole.ADMIN, UserRole.STAFF))

--- a/api/app/routers/items_route.py
+++ b/api/app/routers/items_route.py
@@ -96,7 +96,8 @@ def get_item(
         )
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
 
-@router.post("/", response_model=ItemResponse, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_role(UserRole.ADMIN, UserRole.STAFF))])
+@router.post("", response_model=ItemResponse, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_role(UserRole.ADMIN, UserRole.STAFF))])
+@router.post("/", response_model=ItemResponse, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_role(UserRole.ADMIN, UserRole.STAFF))], include_in_schema=False)
 def create_item(
     item_data: ItemCreate,
     current_user: UserRole = Depends(require_role(UserRole.ADMIN, UserRole.STAFF))

--- a/api/app/routers/locations_route.py
+++ b/api/app/routers/locations_route.py
@@ -45,7 +45,8 @@ def get_location(
         logger.error("Failed to retrieve location", extra={"error": str(e), "location_id": location_id})
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
 
-@router.post("/", response_model=Location, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=Location, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=Location, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_location(
     location_data: LocationCreate,
     current_user=Depends(require_role(UserRole.ADMIN))

--- a/api/app/routers/settings_route.py
+++ b/api/app/routers/settings_route.py
@@ -30,7 +30,8 @@ def get_settings(current_user= Depends(require_role(UserRole.ADMIN))) -> Setting
         logger.error(f"Error retrieving settings: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to retrieve settings.")
     
-@router.put("/", response_model=SettingsResponse)
+@router.put("", response_model=SettingsResponse)
+@router.put("/", response_model=SettingsResponse, include_in_schema=False)
 def update_settings(
     settings_data: SettingsUpdate,
     current_user= Depends(require_role(UserRole.ADMIN))

--- a/api/app/routers/stock_tx_route.py
+++ b/api/app/routers/stock_tx_route.py
@@ -72,7 +72,8 @@ def list_stock_levels(
         logger.error("Failed to list stock levels", extra={"error": str(e)})
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Internal server error")
 
-@router.post("/", response_model=StockTxResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=StockTxResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=StockTxResponse, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_transaction(
     tx_data: StockTxCreate,
     current_user=Depends(require_role(UserRole.ADMIN, UserRole.STAFF))

--- a/api/app/routers/units_route.py
+++ b/api/app/routers/units_route.py
@@ -97,7 +97,8 @@ def get_unit(
             detail=str(e)
         )
 
-@router.post("/", response_model=UnitResponse)
+@router.post("", response_model=UnitResponse)
+@router.post("/", response_model=UnitResponse, include_in_schema=False)
 def create_unit(
     unit_data: UnitCreate,
     current_user=Depends(require_role(UserRole.ADMIN))

--- a/api/app/routers/users_route.py
+++ b/api/app/routers/users_route.py
@@ -77,7 +77,8 @@ def get_user(
             detail=str(e)
         )
 
-@router.post("/register", response_model=UserResponse, dependencies=[Depends(require_role(UserRole.ADMIN))])
+@router.post("", response_model=UserResponse, dependencies=[Depends(require_role(UserRole.ADMIN))])
+@router.post("/register", response_model=UserResponse, dependencies=[Depends(require_role(UserRole.ADMIN))], include_in_schema=False)
 def create_user(
     user_data: UserCreate,
     current_user=Depends(require_role(UserRole.ADMIN))


### PR DESCRIPTION
This pull request standardizes the route definitions for several API endpoints by adding alternate route decorators without a trailing slash and hiding the original slash routes from the OpenAPI schema. This improves consistency in route handling and helps avoid duplicate endpoints in API documentation.

**API route standardization and OpenAPI schema cleanup:**

* Added alternate route decorators without trailing slashes (e.g., `@router.post("")`) to all relevant create/update endpoints, ensuring both with and without trailing slashes are accepted. [[1]](diffhunk://#diff-e7ac1f2a9c4ae4bcb837adb8881271f25c37bf05bf5833307961a25d23026290L95-R96) [[2]](diffhunk://#diff-0d5fa907aac4d2c7bc63060e6982e7a8c18cc50dbde4fc1cdb25143b0d326fefL116-R117) [[3]](diffhunk://#diff-7c2245862b31a6ceec720d0296fe3cc160ab7e6ae5822dd4eef5f2b188daa0c9L228-R229) [[4]](diffhunk://#diff-8e98ba1f2a7cb105da78b7e2b272b1b0db2178d1c097043c54c87f753f83df46L99-R100) [[5]](diffhunk://#diff-7592e19fef038300cec06c626ad547fb0b2e403e59f3a8393c90c8b8167a10abL48-R49) [[6]](diffhunk://#diff-53156f73cea450c433bfbdd61e611d02d7068c315ef26d1f515fe5916704800fL75-R76) [[7]](diffhunk://#diff-54dcd75ef32570bf82a7c6a4c056d94c673f6b8d8aba86287ab79c0c8ff5311dL100-R101) [[8]](diffhunk://#diff-ba3647e04294e16dc010815964e2d2d134269b6a113cf18e81548f0dada99befL80-R81) [[9]](diffhunk://#diff-c6f74740e62cb92b48ed601ce8b3c47e65dc6949f01302caaa576fd327e8c669L33-R34)
* Set `include_in_schema=False` for the original trailing slash routes (e.g., `@router.post("/", ..., include_in_schema=False)`), so only the new routes appear in the OpenAPI schema, preventing duplicate documentation entries. [[1]](diffhunk://#diff-e7ac1f2a9c4ae4bcb837adb8881271f25c37bf05bf5833307961a25d23026290L95-R96) [[2]](diffhunk://#diff-0d5fa907aac4d2c7bc63060e6982e7a8c18cc50dbde4fc1cdb25143b0d326fefL116-R117) [[3]](diffhunk://#diff-7c2245862b31a6ceec720d0296fe3cc160ab7e6ae5822dd4eef5f2b188daa0c9L228-R229) [[4]](diffhunk://#diff-8e98ba1f2a7cb105da78b7e2b272b1b0db2178d1c097043c54c87f753f83df46L99-R100) [[5]](diffhunk://#diff-7592e19fef038300cec06c626ad547fb0b2e403e59f3a8393c90c8b8167a10abL48-R49) [[6]](diffhunk://#diff-53156f73cea450c433bfbdd61e611d02d7068c315ef26d1f515fe5916704800fL75-R76) [[7]](diffhunk://#diff-54dcd75ef32570bf82a7c6a4c056d94c673f6b8d8aba86287ab79c0c8ff5311dL100-R101) [[8]](diffhunk://#diff-ba3647e04294e16dc010815964e2d2d134269b6a113cf18e81548f0dada99befL80-R81) [[9]](diffhunk://#diff-c6f74740e62cb92b48ed601ce8b3c47e65dc6949f01302caaa576fd327e8c669L33-R34)