### PR TITLE
Align Stock Transaction Authorization with STAFF Ownership Rules

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -20,7 +20,7 @@
 ### Current Issues
 - [ ] Hardcoded credentials in `.env` file
 - [x] Missing input validation - direct dict usage in `app/routers/items.py`
-- [ ] CORS for internal network only
+- [x] CORS for internal network only
 
 ## 4. Configuration Management
 
@@ -135,11 +135,11 @@
 - [x] `TransactionFormPage.tsx`
 
 ## Phase 6: Polish & Cleanup (Ongoing)
-- [ ] Remove Bootstrap imports
-- [ ] Remove unused CSS files
-- [ ] Update `main.tsx` (remove Bootstrap CSS)
-- [ ] Optimize Tailwind bundle
-- [ ] Test all responsive breakpoints
+- [x] Remove Bootstrap imports
+- [x] Remove unused CSS files
+- [x] Update `main.tsx` (remove Bootstrap CSS)
+- [x] Optimize Tailwind bundle
+- [x] Test all responsive breakpoints
 - [ ] Cross-browser testing
 - [ ] Performance audit
 

--- a/api/app/routers/stock_tx_route.py
+++ b/api/app/routers/stock_tx_route.py
@@ -28,7 +28,8 @@ def list_transactions(
             item_id=item_id,
             location_id=location_id,
             tx_type=tx_type,
-            search=search
+            search=search,
+            current_user=current_user,
         )
     except HTTPException:
         raise
@@ -42,7 +43,7 @@ def get_transaction(
     current_user=Depends(get_current_user)
 ) -> StockTxResponse:
     try:
-        return StockService.get_transaction(tx_id)
+        return StockService.get_transaction(tx_id, current_user=current_user)
     except HTTPException:
         raise
     except Exception as e:
@@ -79,7 +80,7 @@ def create_transaction(
     current_user=Depends(require_role(UserRole.ADMIN, UserRole.STAFF))
 ) -> StockTxResponse:
     try:
-        return StockService.create_transaction(tx_data, current_user["id"])
+        return StockService.create_transaction(tx_data, current_user=current_user)
     except HTTPException:
         raise
     except Exception as e:
@@ -93,7 +94,7 @@ def update_transaction(
     current_user=Depends(require_role(UserRole.ADMIN, UserRole.STAFF))
 ) -> StockTxResponse:
     try:
-        return StockService.update_transaction(tx_id, tx_data)
+        return StockService.update_transaction(tx_id, tx_data, current_user=current_user)
     except HTTPException:
         raise
     except Exception as e:
@@ -106,7 +107,7 @@ def delete_transaction(
     current_user=Depends(require_role(UserRole.ADMIN, UserRole.STAFF))
 ) -> dict:
     try:
-        return StockService.delete_transaction(tx_id)
+        return StockService.delete_transaction(tx_id, current_user=current_user)
     except HTTPException:
         raise
     except Exception as e:

--- a/api/db/repositories/stock_tx_repo.py
+++ b/api/db/repositories/stock_tx_repo.py
@@ -9,8 +9,31 @@ class StockTxRepository:
 
     @staticmethod
     def get_by_id(tx_id: int) -> Optional[Dict[str, Any]]:
+        return StockTxRepository.get_by_id_scoped(tx_id)
+
+    @staticmethod
+    def get_by_id_scoped(tx_id: int, owner_user_id: Optional[int] = None) -> Optional[Dict[str, Any]]:
         try:
             DatabaseUtils.validate_id(tx_id, "Transaction")
+            owner_clause = ""
+            params: List[Any] = [
+                StockTxRepository.DELETED_LOCATION_NAME_PATTERN,
+                StockTxRepository.DELETED_LOCATION_CODE_PATTERN,
+                tx_id,
+                f"{StockTxRepository.DELETED_NOTE_PREFIX}%",
+            ]
+
+            if owner_user_id is not None:
+                owner_clause = """
+                  AND EXISTS (
+                        SELECT 1
+                        FROM items io
+                        WHERE io.id = st.item_id
+                          AND io.owner_user_id = %s
+                  )
+                """
+                params.append(owner_user_id)
+
             query = """
                 SELECT
                     st.id,
@@ -24,11 +47,14 @@ class StockTxRepository:
                     st.ref,
                     st.note,
                     st.tx_at,
-                    st.user_id
+                    st.user_id,
+                    COALESCE(u.name, '-') AS owner_name
                 FROM stock_tx st
                 LEFT JOIN items i
                     ON st.item_id = i.id
                    AND i.active = 1
+                LEFT JOIN users u
+                    ON st.user_id = u.id
                 LEFT JOIN locations l
                     ON st.location_id = l.id
                    AND l.active = 1
@@ -36,16 +62,10 @@ class StockTxRepository:
                    AND l.code NOT LIKE %s
                 WHERE st.id = %s
                   AND (st.note IS NULL OR st.note NOT LIKE %s)
+                {owner_clause}
             """
-            return fetch_one(
-                query,
-                (
-                    StockTxRepository.DELETED_LOCATION_NAME_PATTERN,
-                    StockTxRepository.DELETED_LOCATION_CODE_PATTERN,
-                    tx_id,
-                    f"{StockTxRepository.DELETED_NOTE_PREFIX}%",
-                ),
-            )
+            query = query.format(owner_clause=owner_clause)
+            return fetch_one(query, tuple(params))
         except Exception as e:
             raise RuntimeError(str(e))
 
@@ -56,7 +76,8 @@ class StockTxRepository:
         item_id: Optional[int] = None,
         location_id: Optional[int] = None,
         tx_type: Optional[str] = None,
-        search: Optional[str] = None
+        search: Optional[str] = None,
+        owner_user_id: Optional[int] = None
     ) -> List[Dict[str, Any]]:
         try:
             conditions = ["(st.note IS NULL OR st.note NOT LIKE %s)"]
@@ -71,6 +92,18 @@ class StockTxRepository:
             if tx_type:
                 conditions.append("st.tx_type = %s")
                 params.append(tx_type)
+            if owner_user_id is not None:
+                conditions.append(
+                    """
+                    EXISTS (
+                        SELECT 1
+                        FROM items io
+                        WHERE io.id = st.item_id
+                          AND io.owner_user_id = %s
+                    )
+                    """
+                )
+                params.append(owner_user_id)
 
             search_term = DatabaseUtils.sanitize_search_term(search)
             search_condition, search_params = QueryBuilder.build_search_condition(
@@ -97,11 +130,14 @@ class StockTxRepository:
                     st.note,
                     st.tx_at,
                     st.user_id,
+                    COALESCE(u.name, '-') AS owner_name,
                     sl.qty_on_hand
                 FROM stock_tx st
                 LEFT JOIN items i
                     ON st.item_id = i.id
                    AND i.active = 1
+                LEFT JOIN users u
+                    ON st.user_id = u.id
                 LEFT JOIN locations l
                     ON st.location_id = l.id
                    AND l.active = 1
@@ -128,7 +164,8 @@ class StockTxRepository:
         item_id: Optional[int] = None,
         location_id: Optional[int] = None,
         tx_type: Optional[str] = None,
-        search: Optional[str] = None
+        search: Optional[str] = None,
+        owner_user_id: Optional[int] = None
     ) -> int:
         try:
             conditions = ["(st.note IS NULL OR st.note NOT LIKE %s)"]
@@ -143,6 +180,18 @@ class StockTxRepository:
             if tx_type:
                 conditions.append("st.tx_type = %s")
                 params.append(tx_type)
+            if owner_user_id is not None:
+                conditions.append(
+                    """
+                    EXISTS (
+                        SELECT 1
+                        FROM items io
+                        WHERE io.id = st.item_id
+                          AND io.owner_user_id = %s
+                    )
+                    """
+                )
+                params.append(owner_user_id)
 
             search_term = DatabaseUtils.sanitize_search_term(search)
             search_condition, search_params = QueryBuilder.build_search_condition(
@@ -214,6 +263,9 @@ class StockTxRepository:
                 if field in tx_data:
                     set_clauses.append(f"{field} = %s")
                     params.append(tx_data[field])
+            if "user_id" in tx_data:
+                set_clauses.append("user_id = %s")
+                params.append(tx_data["user_id"])
 
             if not set_clauses:
                 raise RuntimeError("No fields to update")

--- a/api/domain/services/stock_service.py
+++ b/api/domain/services/stock_service.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict, Any
 from fastapi import HTTPException, status
 from db.pool import get_transaction_cursor
 from db.repositories.item_repo import ItemRepository
@@ -6,6 +6,8 @@ from db.repositories.locations_repo import LocationsRepository
 from db.repositories.stock_levels_repo import StockLevelsRepository
 from db.repositories.stock_tx_repo import StockTxRepository
 from db.repositories.settings_repo import SettingsRepository
+from db.repositories.user_repo import UserRepository
+from schemas.users import UserRole
 from schemas.stock_tx import StockTxCreate, StockTxUpdate, StockTxListResponse, StockTxResponse
 from schemas.stock_levels import StockLevelListResponse, StockLevelResponse
 from core.logging import get_logger
@@ -14,32 +16,103 @@ logger = get_logger(__name__)
 
 class StockService:
     @staticmethod
+    def _is_staff(current_user: Optional[Dict[str, Any]]) -> bool:
+        return bool(current_user) and str(current_user.get("role", "")).upper() == UserRole.STAFF.value
+
+    @staticmethod
+    def _owner_scope(current_user: Optional[Dict[str, Any]]) -> Optional[int]:
+        if StockService._is_staff(current_user):
+            return int(current_user["id"])
+        return None
+
+    @staticmethod
+    def _assert_staff_item_ownership(item_id: int, current_user: Optional[Dict[str, Any]]) -> None:
+        if not StockService._is_staff(current_user):
+            return
+
+        item = ItemRepository.get_by_id(item_id)
+        if not item:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Item not found")
+        if item.get("owner_user_id") != current_user["id"]:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="STAFF can only access transactions for their own items",
+            )
+
+    @staticmethod
+    def _assert_transaction_access(existing_tx: Dict[str, Any], current_user: Optional[Dict[str, Any]]) -> None:
+        if not StockService._is_staff(current_user):
+            return
+        StockService._assert_staff_item_ownership(int(existing_tx["item_id"]), current_user)
+
+    @staticmethod
+    def _resolve_target_owner_user_id(
+        payload_user_id: Optional[int],
+        fallback_user_id: Optional[int],
+        current_user: Optional[Dict[str, Any]],
+    ) -> int:
+        selected_user_id = payload_user_id if payload_user_id is not None else fallback_user_id
+        if selected_user_id is None and current_user:
+            selected_user_id = current_user.get("id")
+        if not isinstance(selected_user_id, int) or selected_user_id <= 0:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid owner user ID")
+        return selected_user_id
+
+    @staticmethod
+    def _validate_target_owner_user(owner_user_id: int) -> None:
+        owner_user = UserRepository.get_by_id(owner_user_id)
+        if not owner_user:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Owner user not found")
+        if not owner_user.get("active", False):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Owner user is inactive")
+
+    @staticmethod
+    def _set_item_owner(cursor, item_id: int, owner_user_id: int) -> None:
+        cursor.execute(
+            """
+            UPDATE items
+            SET owner_user_id = %s
+            WHERE id = %s AND active = 1
+            """,
+            (owner_user_id, item_id),
+        )
+        if cursor.rowcount <= 0:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Failed to update item owner")
+
+    @staticmethod
     def list_transactions(
         page: int = 1,
         page_size: int = 50,
         item_id: Optional[int] = None,
         location_id: Optional[int] = None,
         tx_type: Optional[str] = None,
-        search: Optional[str] = None
+        search: Optional[str] = None,
+        current_user: Optional[Dict[str, Any]] = None,
     ) -> StockTxListResponse:
         if page < 1:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Page number must be at least 1")
         if page_size < 1 or page_size > 100:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Page size must be between 1 and 100")
 
+        if item_id is not None:
+            StockService._assert_staff_item_ownership(item_id, current_user)
+
+        owner_scope = StockService._owner_scope(current_user)
         txs = StockTxRepository.list_transactions(
             page=page,
             page_size=page_size,
             item_id=item_id,
             location_id=location_id,
             tx_type=tx_type,
-            search=search
+            search=search,
+            owner_user_id=owner_scope,
         )
         total = StockTxRepository.count_transactions(
             item_id=item_id,
             location_id=location_id,
             tx_type=tx_type,
-            search=search
+            search=search,
+            owner_user_id=owner_scope,
         )
         return StockTxListResponse(
             txs=[StockTxResponse(**tx) for tx in txs],
@@ -77,20 +150,28 @@ class StockService:
         )
 
     @staticmethod
-    def get_transaction(tx_id: int) -> StockTxResponse:
+    def get_transaction(tx_id: int, current_user: Optional[Dict[str, Any]] = None) -> StockTxResponse:
         tx = StockTxRepository.get_by_id(tx_id)
         if not tx:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+        StockService._assert_transaction_access(tx, current_user)
         return StockTxResponse(**tx)
 
     @staticmethod
-    def create_transaction(tx_data: StockTxCreate, user_id: int) -> StockTxResponse:
+    def create_transaction(tx_data: StockTxCreate, current_user: Dict[str, Any]) -> StockTxResponse:
         StockService._validate_tx_inputs(tx_data.item_id, tx_data.location_id, tx_data.tx_type, tx_data.qty)
 
         if not ItemRepository.exists_by_id(tx_data.item_id):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Item not found")
         if not LocationsRepository.exists_by_id(tx_data.location_id):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Location not found")
+        StockService._assert_staff_item_ownership(tx_data.item_id, current_user)
+        owner_user_id = StockService._resolve_target_owner_user_id(
+            tx_data.user_id,
+            fallback_user_id=None,
+            current_user=current_user,
+        )
+        StockService._validate_target_owner_user(owner_user_id)
 
         allow_negative = StockService._allow_negative_stock()
 
@@ -102,6 +183,7 @@ class StockService:
                 raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Insufficient stock for transaction")
 
             StockService._upsert_stock_level(cursor, tx_data.item_id, tx_data.location_id, new_qty)
+            StockService._set_item_owner(cursor, tx_data.item_id, owner_user_id)
 
             cursor.execute(
                 """
@@ -115,7 +197,7 @@ class StockService:
                     tx_data.qty,
                     tx_data.ref,
                     tx_data.note,
-                    user_id,
+                    owner_user_id,
                 ),
             )
             tx_id = cursor.lastrowid
@@ -127,15 +209,21 @@ class StockService:
         return StockTxResponse(**created)
 
     @staticmethod
-    def update_transaction(tx_id: int, tx_data: StockTxUpdate) -> StockTxResponse:
+    def update_transaction(tx_id: int, tx_data: StockTxUpdate, current_user: Optional[Dict[str, Any]] = None) -> StockTxResponse:
         existing = StockTxRepository.get_by_id(tx_id)
         if not existing:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+        StockService._assert_transaction_access(existing, current_user)
 
         next_item_id = tx_data.item_id if tx_data.item_id is not None else existing["item_id"]
         next_location_id = tx_data.location_id if tx_data.location_id is not None else existing["location_id"]
         next_tx_type = tx_data.tx_type if tx_data.tx_type is not None else existing["tx_type"]
         next_qty = tx_data.qty if tx_data.qty is not None else float(existing["qty"])
+        next_owner_user_id = StockService._resolve_target_owner_user_id(
+            tx_data.user_id,
+            fallback_user_id=existing.get("user_id"),
+            current_user=current_user,
+        )
 
         StockService._validate_tx_inputs(next_item_id, next_location_id, next_tx_type, next_qty)
 
@@ -143,6 +231,8 @@ class StockService:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Item not found")
         if not LocationsRepository.exists_by_id(next_location_id):
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Location not found")
+        StockService._assert_staff_item_ownership(int(next_item_id), current_user)
+        StockService._validate_target_owner_user(next_owner_user_id)
 
         allow_negative = StockService._allow_negative_stock()
 
@@ -164,11 +254,12 @@ class StockService:
                 float(next_qty),
                 allow_negative,
             )
+            StockService._set_item_owner(cursor, int(next_item_id), next_owner_user_id)
 
             cursor.execute(
                 """
                 UPDATE stock_tx
-                SET item_id = %s, location_id = %s, tx_type = %s, qty = %s, ref = %s, note = %s
+                SET item_id = %s, location_id = %s, tx_type = %s, qty = %s, ref = %s, note = %s, user_id = %s
                 WHERE id = %s
                 """,
                 (
@@ -178,6 +269,7 @@ class StockService:
                     next_qty,
                     tx_data.ref if tx_data.ref is not None else existing["ref"],
                     tx_data.note if tx_data.note is not None else existing["note"],
+                    next_owner_user_id,
                     tx_id,
                 ),
             )
@@ -189,10 +281,11 @@ class StockService:
         return StockTxResponse(**updated)
 
     @staticmethod
-    def delete_transaction(tx_id: int) -> dict:
+    def delete_transaction(tx_id: int, current_user: Optional[Dict[str, Any]] = None) -> dict:
         existing = StockTxRepository.get_by_id(tx_id)
         if not existing:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Transaction not found")
+        StockService._assert_transaction_access(existing, current_user)
 
         allow_negative = StockService._allow_negative_stock()
 

--- a/api/schemas/stock_tx.py
+++ b/api/schemas/stock_tx.py
@@ -7,6 +7,7 @@ class StockTxCreate(BaseModel):
     location_id: int = Field(..., description="Identifier for the location")
     tx_type: str = Field(..., description="Type of transaction (IN, OUT, ADJ, XFER)")
     qty: float = Field(..., description="Quantity of items in the transaction")
+    user_id: Optional[int] = Field(None, description="Owner user ID after transaction")
     ref: Optional[str] = Field(None, description="Reference for the transaction")
     note: Optional[str] = Field(None, description="Additional notes about the transaction")
 
@@ -15,6 +16,7 @@ class StockTxUpdate(BaseModel):
     location_id: Optional[int] = Field(None, description="Identifier for the location")
     tx_type: Optional[str] = Field(None, description="Type of transaction (IN, OUT, ADJ, XFER)")
     qty: Optional[float] = Field(None, description="Quantity of items in the transaction")
+    user_id: Optional[int] = Field(None, description="Owner user ID after transaction")
     ref: Optional[str] = Field(None, description="Reference for the transaction")
     note: Optional[str] = Field(None, description="Additional notes about the transaction")
 
@@ -30,7 +32,8 @@ class StockTxResponse(BaseModel):
     ref: Optional[str] = Field(None, description="Reference for the transaction")
     note: Optional[str] = Field(None, description="Additional notes about the transaction")
     tx_at: datetime.datetime = Field(..., description="Timestamp of the transaction")
-    user_id: int = Field(..., description="Identifier for the user who made the transaction")
+    user_id: int = Field(..., description="Identifier for the owner user after transaction")
+    owner_name: Optional[str] = Field(None, description="Owner name derived from user_id")
     qty_on_hand: Optional[float] = Field(None, description="Current quantity on hand after transaction")
 
 class StockTxListResponse(BaseModel):

--- a/api/test/test_stock_service_authorization.py
+++ b/api/test/test_stock_service_authorization.py
@@ -1,0 +1,303 @@
+import pytest
+from fastapi import HTTPException
+
+from domain.services.stock_service import StockService
+from schemas.stock_tx import StockTxCreate, StockTxUpdate
+
+
+STAFF_USER = {
+    "id": 10,
+    "name": "Staff User",
+    "email": "staff@example.com",
+    "role": "STAFF",
+    "active": True,
+}
+
+ADMIN_USER = {
+    "id": 1,
+    "name": "Admin User",
+    "email": "admin@example.com",
+    "role": "ADMIN",
+    "active": True,
+}
+
+
+def test_list_transactions_staff_scopes_owner(monkeypatch):
+    captured = {}
+
+    def fake_list_transactions(**kwargs):
+        captured["list"] = kwargs
+        return []
+
+    def fake_count_transactions(**kwargs):
+        captured["count"] = kwargs
+        return 0
+
+    monkeypatch.setattr("domain.services.stock_service.StockTxRepository.list_transactions", fake_list_transactions)
+    monkeypatch.setattr("domain.services.stock_service.StockTxRepository.count_transactions", fake_count_transactions)
+
+    result = StockService.list_transactions(page=1, page_size=10, current_user=STAFF_USER)
+
+    assert result.total == 0
+    assert captured["list"]["owner_user_id"] == STAFF_USER["id"]
+    assert captured["count"]["owner_user_id"] == STAFF_USER["id"]
+
+
+def test_get_transaction_staff_forbidden_for_foreign_item(monkeypatch):
+    monkeypatch.setattr(
+        "domain.services.stock_service.StockTxRepository.get_by_id",
+        lambda tx_id: {
+            "id": tx_id,
+            "item_id": 99,
+            "item_code": "ITM-099",
+            "item_name": "Foreign Item",
+            "location_id": 1,
+            "location_name": "Main",
+            "tx_type": "IN",
+            "qty": 1,
+            "ref": None,
+            "note": None,
+            "tx_at": "2026-01-01T00:00:00",
+            "user_id": 1,
+            "qty_on_hand": 1,
+        },
+    )
+    monkeypatch.setattr(
+        "domain.services.stock_service.ItemRepository.get_by_id",
+        lambda item_id: {"id": item_id, "owner_user_id": 999, "active": 1},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        StockService.get_transaction(1, current_user=STAFF_USER)
+
+    assert exc.value.status_code == 403
+
+
+def test_create_transaction_staff_forbidden_for_foreign_item(monkeypatch):
+    monkeypatch.setattr("domain.services.stock_service.ItemRepository.exists_by_id", lambda item_id: True)
+    monkeypatch.setattr("domain.services.stock_service.LocationsRepository.exists_by_id", lambda location_id: True)
+    monkeypatch.setattr(
+        "domain.services.stock_service.ItemRepository.get_by_id",
+        lambda item_id: {"id": item_id, "owner_user_id": 999, "active": 1},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        StockService.create_transaction(
+            StockTxCreate(item_id=1, location_id=1, tx_type="IN", qty=1, ref=None, note=None),
+            current_user=STAFF_USER,
+        )
+
+    assert exc.value.status_code == 403
+
+
+def test_create_transaction_defaults_owner_to_authenticated_user_id_when_missing(monkeypatch):
+    captured = {"insert_params": None, "item_owner_update": None}
+
+    class DummyCursor:
+        def __init__(self):
+            self.lastrowid = 123
+            self.rowcount = 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query, params=None):
+            if "INSERT INTO stock_tx" in query:
+                captured["insert_params"] = params
+            if "UPDATE items" in query and "owner_user_id" in query:
+                captured["item_owner_update"] = params
+
+    monkeypatch.setattr("domain.services.stock_service.ItemRepository.exists_by_id", lambda item_id: True)
+    monkeypatch.setattr("domain.services.stock_service.LocationsRepository.exists_by_id", lambda location_id: True)
+    monkeypatch.setattr(
+        "domain.services.stock_service.UserRepository.get_by_id",
+        lambda user_id: {"id": user_id, "name": "Any User", "active": True},
+    )
+    monkeypatch.setattr(
+        "domain.services.stock_service.ItemRepository.get_by_id",
+        lambda item_id: {"id": item_id, "owner_user_id": STAFF_USER["id"], "active": 1},
+    )
+    monkeypatch.setattr("domain.services.stock_service.StockService._allow_negative_stock", lambda: True)
+    monkeypatch.setattr("domain.services.stock_service.StockService._get_qty_for_update", lambda cursor, item_id, location_id: 0.0)
+    monkeypatch.setattr("domain.services.stock_service.StockService._apply_effect", lambda current_qty, tx_type, qty: current_qty + qty)
+    monkeypatch.setattr("domain.services.stock_service.StockService._upsert_stock_level", lambda cursor, item_id, location_id, qty_on_hand: None)
+    monkeypatch.setattr("domain.services.stock_service.get_transaction_cursor", lambda dictionary=True: DummyCursor())
+    monkeypatch.setattr(
+        "domain.services.stock_service.StockTxRepository.get_by_id",
+        lambda tx_id: {
+            "id": tx_id,
+            "item_id": 1,
+            "item_code": "ITM-001",
+            "item_name": "Owned Item",
+            "location_id": 1,
+            "location_name": "Main",
+            "tx_type": "IN",
+            "qty": 5,
+            "ref": None,
+            "note": None,
+            "tx_at": "2026-01-01T00:00:00",
+            "user_id": STAFF_USER["id"],
+            "qty_on_hand": 0,
+        },
+    )
+
+    response = StockService.create_transaction(
+        StockTxCreate(item_id=1, location_id=1, tx_type="IN", qty=5, ref=None, note=None),
+        current_user=STAFF_USER,
+    )
+
+    assert response.user_id == STAFF_USER["id"]
+    assert captured["insert_params"][-1] == STAFF_USER["id"]
+    assert captured["item_owner_update"] == (STAFF_USER["id"], 1)
+
+
+def test_create_transaction_uses_payload_owner_user_id_and_updates_item_owner(monkeypatch):
+    captured = {"insert_params": None, "item_owner_update": None}
+
+    class DummyCursor:
+        def __init__(self):
+            self.lastrowid = 124
+            self.rowcount = 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query, params=None):
+            if "INSERT INTO stock_tx" in query:
+                captured["insert_params"] = params
+            if "UPDATE items" in query and "owner_user_id" in query:
+                captured["item_owner_update"] = params
+                self.rowcount = 1
+
+    monkeypatch.setattr("domain.services.stock_service.ItemRepository.exists_by_id", lambda item_id: True)
+    monkeypatch.setattr("domain.services.stock_service.LocationsRepository.exists_by_id", lambda location_id: True)
+    monkeypatch.setattr(
+        "domain.services.stock_service.ItemRepository.get_by_id",
+        lambda item_id: {"id": item_id, "owner_user_id": STAFF_USER["id"], "active": 1},
+    )
+    monkeypatch.setattr(
+        "domain.services.stock_service.UserRepository.get_by_id",
+        lambda user_id: {"id": user_id, "name": "Target Owner", "active": True},
+    )
+    monkeypatch.setattr("domain.services.stock_service.StockService._allow_negative_stock", lambda: True)
+    monkeypatch.setattr("domain.services.stock_service.StockService._get_qty_for_update", lambda cursor, item_id, location_id: 0.0)
+    monkeypatch.setattr("domain.services.stock_service.StockService._apply_effect", lambda current_qty, tx_type, qty: current_qty + qty)
+    monkeypatch.setattr("domain.services.stock_service.StockService._upsert_stock_level", lambda cursor, item_id, location_id, qty_on_hand: None)
+    monkeypatch.setattr("domain.services.stock_service.get_transaction_cursor", lambda dictionary=True: DummyCursor())
+    monkeypatch.setattr(
+        "domain.services.stock_service.StockTxRepository.get_by_id",
+        lambda tx_id: {
+            "id": tx_id,
+            "item_id": 1,
+            "item_code": "ITM-001",
+            "item_name": "Owned Item",
+            "location_id": 1,
+            "location_name": "Main",
+            "tx_type": "IN",
+            "qty": 5,
+            "ref": None,
+            "note": None,
+            "tx_at": "2026-01-01T00:00:00",
+            "user_id": 77,
+            "owner_name": "Target Owner",
+            "qty_on_hand": 0,
+        },
+    )
+
+    response = StockService.create_transaction(
+        StockTxCreate(item_id=1, location_id=1, tx_type="IN", qty=5, user_id=77, ref=None, note=None),
+        current_user=STAFF_USER,
+    )
+
+    assert response.user_id == 77
+    assert captured["insert_params"][-1] == 77
+    assert captured["item_owner_update"] == (77, 1)
+
+
+def test_update_transaction_staff_forbidden_when_target_item_is_foreign(monkeypatch):
+    monkeypatch.setattr(
+        "domain.services.stock_service.StockTxRepository.get_by_id",
+        lambda tx_id: {
+            "id": tx_id,
+            "item_id": 1,
+            "item_code": "ITM-001",
+            "item_name": "Owned Item",
+            "location_id": 1,
+            "location_name": "Main",
+            "tx_type": "IN",
+            "qty": 2.0,
+            "ref": None,
+            "note": None,
+            "tx_at": "2026-01-01T00:00:00",
+            "user_id": STAFF_USER["id"],
+            "qty_on_hand": 2,
+        },
+    )
+    monkeypatch.setattr("domain.services.stock_service.ItemRepository.exists_by_id", lambda item_id: True)
+    monkeypatch.setattr("domain.services.stock_service.LocationsRepository.exists_by_id", lambda location_id: True)
+
+    def fake_get_item(item_id):
+        if item_id == 1:
+            return {"id": 1, "owner_user_id": STAFF_USER["id"], "active": 1}
+        return {"id": item_id, "owner_user_id": 999, "active": 1}
+
+    monkeypatch.setattr("domain.services.stock_service.ItemRepository.get_by_id", fake_get_item)
+
+    with pytest.raises(HTTPException) as exc:
+        StockService.update_transaction(
+            1,
+            StockTxUpdate(item_id=2),
+            current_user=STAFF_USER,
+        )
+
+    assert exc.value.status_code == 403
+
+
+def test_delete_transaction_admin_allowed(monkeypatch):
+    monkeypatch.setattr(
+        "domain.services.stock_service.StockTxRepository.get_by_id",
+        lambda tx_id: {
+            "id": tx_id,
+            "item_id": 1,
+            "item_code": "ITM-001",
+            "item_name": "Owned Item",
+            "location_id": 1,
+            "location_name": "Main",
+            "tx_type": "IN",
+            "qty": 1.0,
+            "ref": None,
+            "note": None,
+            "tx_at": "2026-01-01T00:00:00",
+            "user_id": ADMIN_USER["id"],
+            "qty_on_hand": 1,
+        },
+    )
+    monkeypatch.setattr("domain.services.stock_service.StockService._allow_negative_stock", lambda: True)
+    monkeypatch.setattr(
+        "domain.services.stock_service.StockService._reverse_transaction",
+        lambda cursor, item_id, location_id, tx_type, qty, allow_negative: None,
+    )
+
+    class DummyCursor:
+        def __init__(self):
+            self.rowcount = 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, query, params=None):
+            self.rowcount = 1
+
+    monkeypatch.setattr("domain.services.stock_service.get_transaction_cursor", lambda dictionary=True: DummyCursor())
+
+    result = StockService.delete_transaction(1, current_user=ADMIN_USER)
+    assert result["transaction_id"] == 1

--- a/front-end/src/components/AuditSessionsPage.tsx
+++ b/front-end/src/components/AuditSessionsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { Eye, ScanLine } from 'lucide-react';
 import {
     Alert,
     Badge,
@@ -291,7 +292,7 @@ function AuditSessionsPage() {
                                             <th>Status</th>
                                             <th>Started</th>
                                             <th>Scanned / Expected</th>
-                                            <th className="text-right">Actions</th>
+                                            <th className="w-24 text-center">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -313,22 +314,28 @@ function AuditSessionsPage() {
                                                 <td className="text-sm">
                                                     {session.scanned_count} / {session.expected_count}
                                                 </td>
-                                                <td className="text-right">
-                                                    <div className="flex gap-2 justify-end">
+                                                <td className="text-center">
+                                                    <div className="flex gap-1 justify-center">
                                                         <Button
                                                             variant="outline-primary"
                                                             size="sm"
+                                                            className="px-2"
+                                                            title="View audit session"
+                                                            aria-label="View audit session"
                                                             onClick={() => navigate(`/audit/${session.id}`)}
                                                         >
-                                                            View
+                                                            <Eye className="w-4 h-4" />
                                                         </Button>
                                                         {session.status === 'OPEN' && (
                                                             <Button
                                                                 variant="primary"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Scan audit session"
+                                                                aria-label="Scan audit session"
                                                                 onClick={() => navigate(`/audit/${session.id}/scan`)}
                                                             >
-                                                                Scan
+                                                                <ScanLine className="w-4 h-4" />
                                                             </Button>
                                                         )}
                                                     </div>

--- a/front-end/src/components/CategoryPage.tsx
+++ b/front-end/src/components/CategoryPage.tsx
@@ -283,7 +283,7 @@ function CategoryPage() {
                                             >
                                                 Name {getSortIndicator('name')}
                                             </th>
-                                            <th className="w-48 text-right text-xs uppercase tracking-wide text-gray-500">Actions</th>
+                                            <th className="w-24 text-center text-xs uppercase tracking-wide text-gray-500">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -295,26 +295,28 @@ function CategoryPage() {
                                                     </code>
                                                 </td>
                                                 <td className="font-semibold">{category.name}</td>
-                                                <td className="text-right">
+                                                <td className="text-center">
                                                     {canManageCategories && (
-                                                        <div className="flex gap-2 justify-end">
+                                                        <div className="flex gap-1 justify-center">
                                                             <Button
                                                                 variant="outline-primary"
                                                                 size="sm"
-                                                                className="text-xs"
+                                                                className="text-xs px-2"
+                                                                title="Edit category"
+                                                                aria-label="Edit category"
                                                                 onClick={() => handleOpenModal(category)}
                                                             >
-                                                                <Pencil className="w-4 h-4 mr-1" />
-                                                                Edit
+                                                                <Pencil className="w-4 h-4" />
                                                             </Button>
                                                             <Button
                                                                 variant="outline-danger"
                                                                 size="sm"
-                                                                className="text-xs"
+                                                                className="text-xs px-2"
+                                                                title="Delete category"
+                                                                aria-label="Delete category"
                                                                 onClick={() => handleDelete(category.id)}
                                                             >
-                                                                <Trash2 className="w-4 h-4 mr-1" />
-                                                                Delete
+                                                                <Trash2 className="w-4 h-4" />
                                                             </Button>
                                                         </div>
                                                     )}

--- a/front-end/src/components/Dashboard.tsx
+++ b/front-end/src/components/Dashboard.tsx
@@ -481,7 +481,7 @@ function Dashboard() {
                                                 Issued At {getSortIndicator('issued_at')}
                                             </th>
                                             <th>Note</th>
-                                            <th className="w-64">Actions</th>
+                                            <th className="w-28 text-center">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -503,34 +503,40 @@ function Dashboard() {
                                                     {issue.issued_at ? new Date(issue.issued_at).toLocaleDateString() : '-'}
                                                 </td>
                                                 <td className="text-sm max-w-xs truncate">{issue.note || '-'}</td>
-                                                <td onClick={(e) => e.stopPropagation()}>
-                                                    <div className="flex gap-2">
+                                                <td onClick={(e) => e.stopPropagation()} className="text-center">
+                                                    <div className="flex items-center justify-center gap-1">
                                                         <Button
                                                             variant="outline-secondary"
                                                             size="sm"
+                                                            className="px-2"
+                                                            title="View issue items"
+                                                            aria-label="View issue items"
                                                             onClick={() => navigate(`/issues/${issue.id}/items`)}
                                                         >
-                                                            <Eye className="w-4 h-4 mr-1" />
-                                                            View
+                                                            <Eye className="w-4 h-4" />
                                                         </Button>
                                                         {(user?.role === 'ADMIN' || (user?.role === 'STAFF' && canAccessIssue(issue))) && (
                                                             <>
                                                                 <Button
                                                                     variant="outline-primary"
                                                                     size="sm"
+                                                                    className="px-2"
+                                                                    title="Edit issue"
+                                                                    aria-label="Edit issue"
                                                                     onClick={() => navigate(`/issues/${issue.id}/edit`)}
                                                                 >
-                                                                    <Pencil className="w-4 h-4 mr-1" />
-                                                                    Edit
+                                                                    <Pencil className="w-4 h-4" />
                                                                 </Button>
                                                                 {user?.role === 'ADMIN' && (
                                                                     <Button
                                                                         variant="outline-danger"
                                                                         size="sm"
+                                                                        className="px-2"
+                                                                        title="Delete issue"
+                                                                        aria-label="Delete issue"
                                                                         onClick={() => handleDeleteIssue(issue.id)}
                                                                     >
-                                                                        <Trash2 className="w-4 h-4 mr-1" />
-                                                                        Delete
+                                                                        <Trash2 className="w-4 h-4" />
                                                                     </Button>
                                                                 )}
                                                             </>

--- a/front-end/src/components/ItemFormPage.tsx
+++ b/front-end/src/components/ItemFormPage.tsx
@@ -403,14 +403,14 @@ function ItemFormPage() {
                                 />
                                 {isStaff ? (
                                     <FormInput
-                                        label="Owner"
+                                        label="Assigned to"
                                         value={user?.name || '-'}
-                                        onChange={(_e) => {}}
+                                        onChange={() => {}}
                                         disabled
                                     />
                                 ) : (
                                     <FormSelect
-                                        label="Owner"
+                                        label="Assigned to"
                                         options={ownerOptions}
                                         value={form.owner_user_id}
                                         onChange={(e) => handleChange('owner_user_id', e.target.value)}

--- a/front-end/src/components/ItemsPage.tsx
+++ b/front-end/src/components/ItemsPage.tsx
@@ -548,7 +548,7 @@ function ItemsPage() {
                                             <th className="text-xs uppercase tracking-wide text-gray-500">Description</th>
                                             <th className="text-center text-xs uppercase tracking-wide text-gray-500">Min Stock</th>
                                             <th className="text-center text-xs uppercase tracking-wide text-gray-500">Status</th>
-                                            <th className="w-56 text-right text-xs uppercase tracking-wide text-gray-500">Actions</th>
+                                            <th className="w-24 text-center text-xs uppercase tracking-wide text-gray-500">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -587,28 +587,30 @@ function ItemsPage() {
                                                         {item.active ? 'Active' : 'Inactive'}
                                                     </Badge>
                                                 </td>
-                                                <td onClick={(e) => e.stopPropagation()} className="text-right">
+                                                <td onClick={(e) => e.stopPropagation()} className="text-center">
                                                     {(currentUser?.role === 'ADMIN' || currentUser?.role === 'STAFF') && (
-                                                        <div className="flex gap-2 justify-end">
+                                                        <div className="flex gap-1 justify-center">
                                                             <Button
                                                                 variant="outline-primary"
                                                                 size="sm"
-                                                                className="text-xs"
+                                                                className="text-xs px-2"
+                                                                title="Edit item"
+                                                                aria-label="Edit item"
                                                                 onClick={() => navigate(`/items/${item.id}/edit`)}
                                                                 disabled={isStaff && item.owner_user_id !== currentUser?.id}
                                                             >
-                                                                <Pencil className="w-4 h-4 mr-1" />
-                                                                Edit
+                                                                <Pencil className="w-4 h-4" />
                                                             </Button>
                                                             {currentUser?.role === 'ADMIN' && (
                                                                 <Button
                                                                     variant="outline-danger"
                                                                     size="sm"
-                                                                    className="text-xs"
+                                                                    className="text-xs px-2"
+                                                                    title="Delete item"
+                                                                    aria-label="Delete item"
                                                                     onClick={() => handleDeleteItem(item.id)}
                                                                 >
-                                                                    <Trash2 className="w-4 h-4 mr-1" />
-                                                                    Delete
+                                                                    <Trash2 className="w-4 h-4" />
                                                                 </Button>
                                                             )}
                                                         </div>

--- a/front-end/src/components/LocationsPage.tsx
+++ b/front-end/src/components/LocationsPage.tsx
@@ -322,7 +322,7 @@ function LocationsPage() {
                                             >
                                                 Status {getSortIndicator('active')}
                                             </th>
-                                            <th className="w-56 text-right text-xs uppercase tracking-wide text-gray-500">Actions</th>
+                                            <th className="w-24 text-center text-xs uppercase tracking-wide text-gray-500">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -342,24 +342,28 @@ function LocationsPage() {
                                                         {location.active ? 'Active' : 'Inactive'}
                                                     </Badge>
                                                 </td>
-                                                <td className="text-right">
+                                                <td className="text-center">
                                                     {currentUser?.role === 'ADMIN' && (
-                                                        <div className="flex gap-2 justify-end">
+                                                        <div className="flex gap-1 justify-center">
                                                             <Button
                                                                 variant="outline-primary"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Edit location"
+                                                                aria-label="Edit location"
                                                                 onClick={() => handleOpenModal(location)}
                                                             >
-                                                                <Pencil className="w-4 h-4 mr-1" />
-                                                                Edit
+                                                                <Pencil className="w-4 h-4" />
                                                             </Button>
                                                             <Button
                                                                 variant="outline-danger"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Delete location"
+                                                                aria-label="Delete location"
                                                                 onClick={() => handleDelete(location.id)}
                                                             >
-                                                                <Trash2 className="w-4 h-4 mr-1" />
-                                                                Delete
+                                                                <Trash2 className="w-4 h-4" />
                                                             </Button>
                                                         </div>
                                                     )}

--- a/front-end/src/components/TransactionFormPage.tsx
+++ b/front-end/src/components/TransactionFormPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { ArrowLeft } from 'lucide-react';
 import Select from 'react-select';
@@ -33,27 +33,82 @@ interface ItemSelectOption {
     label: string;
 }
 
+interface UserOption {
+    id: number;
+    name: string;
+    email: string;
+    role?: string;
+    active?: boolean;
+}
+
+interface TransactionDetailResponse {
+    id: number;
+    item_id: number;
+    location_id: number;
+    tx_type: string;
+    qty: number;
+    user_id: number;
+    ref?: string | null;
+    note?: string | null;
+}
+
 interface TransactionFormState {
     item_id: string;
     location_id: string;
     tx_type: string;
     qty: string;
+    user_id: string;
     ref: string;
     note: string;
 }
 
+function formatApiErrorDetail(detail: unknown, fallback: string): string {
+    if (!detail) return fallback;
+    if (typeof detail === 'string') return detail;
+    if (Array.isArray(detail)) {
+        return detail
+            .map((entry) => {
+                if (typeof entry === 'string') return entry;
+                if (entry && typeof entry === 'object') {
+                    const msg = 'msg' in entry ? String((entry as { msg?: unknown }).msg) : '';
+                    const loc = 'loc' in entry && Array.isArray((entry as { loc?: unknown[] }).loc)
+                        ? (entry as { loc?: unknown[] }).loc?.join('.')
+                        : '';
+                    return loc ? `${loc}: ${msg}` : msg;
+                }
+                return String(entry);
+            })
+            .filter(Boolean)
+            .join('; ') || fallback;
+    }
+    if (typeof detail === 'object') {
+        try {
+            return JSON.stringify(detail);
+        } catch {
+            return fallback;
+        }
+    }
+    return String(detail);
+}
+
 function TransactionFormPage() {
     const navigate = useNavigate();
+    const { txId } = useParams<{ txId?: string }>();
+    const isEditMode = Boolean(txId);
     const { user, isLoading: authLoading } = useAuth();
+    const isStaff = user?.role === 'STAFF';
     const [isLoading, setIsLoading] = useState(false);
+    const [isPageLoading, setIsPageLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [locations, setLocations] = useState<Location[]>([]);
     const [items, setItems] = useState<Item[]>([]);
+    const [users, setUsers] = useState<UserOption[]>([]);
     const [form, setForm] = useState<TransactionFormState>({
         item_id: '',
         location_id: '',
         tx_type: 'IN',
         qty: '',
+        user_id: '',
         ref: '',
         note: '',
     });
@@ -70,88 +125,100 @@ function TransactionFormPage() {
     useEffect(() => {
         if (!token) return;
 
-        const loadMetadata = async () => {
+        const loadFormData = async () => {
+            setIsPageLoading(true);
             try {
-                const [locRes, itemRes] = await Promise.all([
+                const requests: Promise<Response>[] = [
                     fetch(`${API_BASE_URL}/locations?page=1&page_size=200`, {
                         headers: { 'Authorization': `Bearer ${token}` },
                     }),
                     fetch(`${API_BASE_URL}/items?page=1&page_size=100&active_only=1`, {
                         headers: { 'Authorization': `Bearer ${token}` },
                     }),
-                ]);
+                    fetch(`${API_BASE_URL}/users?page=1&page_size=100&active_only=1`, {
+                        headers: { 'Authorization': `Bearer ${token}` },
+                    }),
+                ];
+
+                if (isEditMode && txId) {
+                    requests.push(
+                        fetch(`${API_BASE_URL}/transactions/${txId}`, {
+                            headers: { 'Authorization': `Bearer ${token}` },
+                        })
+                    );
+                }
+
+                const responses = await Promise.all(requests);
+                const [locRes, itemRes, usersRes, txRes] = responses;
 
                 if (!locRes.ok) {
                     const err = await locRes.json().catch(() => ({}));
-                    throw new Error(err.detail || 'Failed to load locations');
+                    throw new Error(formatApiErrorDetail(err.detail, 'Failed to load locations'));
                 }
                 if (!itemRes.ok) {
                     const err = await itemRes.json().catch(() => ({}));
-                    throw new Error(err.detail || 'Failed to load items');
+                    throw new Error(formatApiErrorDetail(err.detail, 'Failed to load items'));
+                }
+                if (!usersRes.ok) {
+                    const err = await usersRes.json().catch(() => ({}));
+                    throw new Error(formatApiErrorDetail(err.detail, 'Failed to load users'));
+                }
+                if (txRes && !txRes.ok) {
+                    const err = await txRes.json().catch(() => ({}));
+                    throw new Error(formatApiErrorDetail(err.detail, 'Failed to load transaction'));
                 }
 
-                const [locData, itemData] = await Promise.all([locRes.json(), itemRes.json()]);
+                const [locData, itemData, usersData] = await Promise.all([
+                    locRes.json(),
+                    itemRes.json(),
+                    usersRes.json(),
+                ]);
+
                 setLocations(locData || []);
                 setItems(itemData.items || []);
+
+                const nextUsers: UserOption[] = Array.isArray(usersData) ? usersData : (usersData.users || []);
+                setUsers(nextUsers);
+
+                if (txRes) {
+                    const txData: TransactionDetailResponse = await txRes.json();
+                    setForm({
+                        item_id: String(txData.item_id ?? ''),
+                        location_id: String(txData.location_id ?? ''),
+                        tx_type: txData.tx_type || 'IN',
+                        qty: txData.qty !== undefined && txData.qty !== null ? String(txData.qty) : '',
+                        user_id: txData.user_id ? String(txData.user_id) : '',
+                        ref: txData.ref || '',
+                        note: txData.note || '',
+                    });
+                } else if (user?.id) {
+                    setForm((prev) => ({
+                        ...prev,
+                        user_id: prev.user_id || String(user.id),
+                    }));
+                }
             } catch (err) {
                 setError((err as Error).message || 'Failed to load form data');
                 console.error('Error loading metadata:', err);
+            } finally {
+                setIsPageLoading(false);
             }
         };
 
-        loadMetadata();
-    }, [API_BASE_URL, token]);
+        loadFormData();
+    }, [API_BASE_URL, token, isEditMode, txId, user?.id]);
+
+    useEffect(() => {
+        if (!user?.id) return;
+        setForm((prev) => ({
+            ...prev,
+            user_id: prev.user_id || String(user.id),
+        }));
+    }, [user?.id]);
 
     const handleChange = (field: keyof TransactionFormState, value: string) => {
         setForm((prev) => ({ ...prev, [field]: value }));
     };
-
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        if (!token) return;
-
-        setIsLoading(true);
-        setError(null);
-
-        const payload = {
-            item_id: Number(form.item_id),
-            location_id: Number(form.location_id),
-            tx_type: form.tx_type,
-            qty: Number(form.qty),
-            ref: form.ref.trim() || null,
-            note: form.note.trim() || null,
-        };
-
-        try {
-            const response = await fetch(`${API_BASE_URL}/transactions`, {
-                method: 'POST',
-                headers: {
-                    'Authorization': `Bearer ${token}`,
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify(payload),
-            });
-
-            if (!response.ok) {
-                const err = await response.json();
-                throw new Error(err.detail || 'Failed to create transaction');
-            }
-
-            navigate('/transactions');
-        } catch (err) {
-            setError((err as Error).message || 'Failed to create transaction');
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    if (authLoading) {
-        return (
-            <div className="flex items-center justify-center py-12">
-                <Spinner size="lg" />
-            </div>
-        );
-    }
 
     const itemOptions = useMemo<ItemSelectOption[]>(
         () =>
@@ -165,6 +232,65 @@ function TransactionFormPage() {
         if (!form.item_id) return null;
         return itemOptions.find((option) => option.value === form.item_id) || null;
     }, [form.item_id, itemOptions]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!token) return;
+
+        setIsLoading(true);
+        setError(null);
+
+        const payload: {
+            item_id: number;
+            location_id: number;
+            tx_type: string;
+            qty: number;
+            user_id: number;
+            ref: string | null;
+            note: string | null;
+        } = {
+            item_id: Number(form.item_id),
+            location_id: Number(form.location_id),
+            tx_type: form.tx_type,
+            qty: Number(form.qty),
+            user_id: Number(form.user_id),
+            ref: form.ref.trim() || null,
+            note: form.note.trim() || null,
+        };
+
+        try {
+            const response = await fetch(
+                isEditMode && txId ? `${API_BASE_URL}/transactions/${txId}` : `${API_BASE_URL}/transactions`,
+                {
+                method: isEditMode ? 'PUT' : 'POST',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+                }
+            );
+
+            if (!response.ok) {
+                const err = await response.json();
+                throw new Error(err.detail || `Failed to ${isEditMode ? 'update' : 'create'} transaction`);
+            }
+
+            navigate('/transactions');
+        } catch (err) {
+            setError((err as Error).message || `Failed to ${isEditMode ? 'update' : 'create'} transaction`);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    if (authLoading || isPageLoading) {
+        return (
+            <div className="flex items-center justify-center py-12">
+                <Spinner size="lg" />
+            </div>
+        );
+    }
 
     const locationOptions = [
         { value: '', label: 'Select location' },
@@ -181,6 +307,14 @@ function TransactionFormPage() {
         { value: 'XFER', label: 'XFER (Transfer)' },
     ];
 
+    const ownerOptions = [
+        { value: '', label: 'Select owner' },
+        ...users.map((owner) => ({
+            value: String(owner.id),
+            label: owner.name,
+        })),
+    ];
+
     return (
         <div className="w-full h-full">
             <div className="px-4 py-6 max-w-2xl mx-auto">
@@ -192,8 +326,17 @@ function TransactionFormPage() {
                         <ArrowLeft className="w-6 h-6" />
                     </button>
                     <div>
-                        <h2 className="text-3xl font-bold text-gray-900">New Stock Transaction</h2>
-                        <p className="text-gray-600 mt-1">Record a stock transaction</p>
+                        <h2 className="text-3xl font-bold text-gray-900">
+                            {isEditMode ? 'Edit Stock Transaction' : 'New Stock Transaction'}
+                        </h2>
+                        <p className="text-gray-600 mt-1">
+                            {isEditMode ? 'Update a stock transaction' : 'Record a stock transaction'}
+                        </p>
+                        {isStaff && (
+                            <p className="text-xs text-amber-700 mt-1">
+                                You can create transactions only for items assigned to you.
+                            </p>
+                        )}
                     </div>
                 </div>
 
@@ -220,6 +363,9 @@ function TransactionFormPage() {
                                         placeholder="Search item code or name"
                                         classNamePrefix="react-select"
                                     />
+                                    {isStaff && (
+                                        <p className="text-xs text-gray-500 mt-1">Showing your owned items only.</p>
+                                    )}
                                 </div>
                                 <FormSelect
                                     label="Location"
@@ -233,6 +379,13 @@ function TransactionFormPage() {
                                     options={typeOptions}
                                     value={form.tx_type}
                                     onChange={(e) => handleChange('tx_type', e.target.value)}
+                                    required
+                                />
+                                <FormSelect
+                                    label="Assigned to"
+                                    options={ownerOptions}
+                                    value={form.user_id}
+                                    onChange={(e) => handleChange('user_id', e.target.value)}
                                     required
                                 />
                                 <FormInput
@@ -267,18 +420,14 @@ function TransactionFormPage() {
                         <Button variant="secondary" onClick={() => navigate('/transactions')}>
                             Cancel
                         </Button>
-                        <Button
-                            variant="primary"
-                            onClick={handleSubmit}
-                            disabled={isLoading}
-                        >
+                        <Button variant="primary" onClick={handleSubmit} disabled={isLoading}>
                             {isLoading ? (
                                 <>
                                     <Spinner size="sm" className="mr-2" />
                                     Saving...
                                 </>
                             ) : (
-                                <>Save Transaction</>
+                                <>{isEditMode ? 'Save Changes' : 'Save Transaction'}</>
                             )}
                         </Button>
                     </CardFooter>

--- a/front-end/src/components/TransactionsPage.tsx
+++ b/front-end/src/components/TransactionsPage.tsx
@@ -29,6 +29,7 @@ interface Transaction {
     note?: string | null;
     tx_at: string;
     user_id: number;
+    owner_name?: string | null;
 }
 
 interface TransactionListResponse {
@@ -51,6 +52,7 @@ interface LocationOption {
 
 function TransactionsPage() {
     const { user: currentUser, isLoading: authLoading } = useAuth();
+    const isStaff = currentUser?.role === 'STAFF';
     const navigate = useNavigate();
     const [transactions, setTransactions] = useState<Transaction[]>([]);
     const [items, setItems] = useState<ItemOption[]>([]);
@@ -213,7 +215,7 @@ function TransactionsPage() {
 
     return (
         <div className="w-full h-full">
-            <div className="px-4 py-6 w-full">
+            <div className="px-4 py-6 max-w-7xl mx-auto">
                 <div className="flex justify-between items-start mb-6">
                     <div>
                         <h2 className="text-3xl font-bold text-gray-900 flex items-center gap-2">
@@ -221,6 +223,11 @@ function TransactionsPage() {
                             Stock Transactions
                         </h2>
                         <p className="text-gray-600 mt-1">Track stock movements and adjustments</p>
+                        {isStaff && (
+                            <p className="text-xs text-amber-700 mt-1">
+                                STAFF view is limited to transactions for items you own.
+                            </p>
+                        )}
                     </div>
                     {(currentUser?.role === 'ADMIN' || currentUser?.role === 'STAFF') && (
                         <Button variant="primary" onClick={() => navigate('/transactions/new')}>
@@ -273,6 +280,9 @@ function TransactionsPage() {
                                         </option>
                                     ))}
                                 </select>
+                                {isStaff && (
+                                    <p className="text-xs text-gray-500 mt-1">Showing your owned items only.</p>
+                                )}
                             </div>
                             <div>
                                 <label className="form-label">Location</label>
@@ -304,66 +314,96 @@ function TransactionsPage() {
                                 <p className="text-lg">No transactions found</p>
                             </div>
                         ) : (
-                            <div className="table-responsive">
-                                <table className="table table-compact">
+                            <div className="table-responsive max-w-full overflow-x-auto">
+                                <table className="table table-compact text-sm">
                                     <thead>
                                         <tr>
-                                            <th>Date</th>
-                                            <th>Item Code</th>
-                                            <th>Item Name</th>
-                                            <th>Location</th>
-                                            <th>Type</th>
-                                            <th>Qty</th>
-                                            <th>On Hand</th>
-                                            <th>Ref</th>
-                                            <th>Note</th>
-                                            <th className="w-48">Actions</th>
+                                            <th className="whitespace-nowrap text-xs uppercase tracking-wide text-gray-500">Date</th>
+                                            <th className="whitespace-nowrap text-xs uppercase tracking-wide text-gray-500">Item Code</th>
+                                            <th className="whitespace-nowrap text-xs uppercase tracking-wide text-gray-500">Item Name</th>
+                                            <th className="whitespace-nowrap text-xs uppercase tracking-wide text-gray-500">Location</th>
+                                            <th className="whitespace-nowrap text-xs uppercase tracking-wide text-gray-500 text-center">Type</th>
+                                            <th className="whitespace-nowrap text-xs uppercase tracking-wide text-gray-500 text-right">Qty</th>
+                                            <th className="whitespace-nowrap text-xs uppercase tracking-wide text-gray-500 text-right">On Hand</th>
+                                            <th className="hidden xl:table-cell whitespace-nowrap text-xs uppercase tracking-wide text-gray-500">Ref</th>
+                                            <th className="whitespace-nowrap text-xs uppercase tracking-wide text-gray-500">Assigned to</th>
+                                            <th className="hidden 2xl:table-cell whitespace-nowrap text-xs uppercase tracking-wide text-gray-500">Note</th>
+                                            <th className="w-24 whitespace-nowrap text-xs uppercase tracking-wide text-gray-500 text-center">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {transactions.map((tx) => (
                                             <tr key={tx.id}>
-                                                <td>{new Date(tx.tx_at).toLocaleString()}</td>
-                                                <td>
-                                                    <code className="text-blue-600 font-mono text-sm">
+                                                <td className="whitespace-nowrap text-xs">
+                                                    <div>{new Date(tx.tx_at).toLocaleDateString()}</div>
+                                                    <div className="text-gray-500">
+                                                        {new Date(tx.tx_at).toLocaleTimeString([], {
+                                                            hour: '2-digit',
+                                                            minute: '2-digit',
+                                                        })}
+                                                    </div>
+                                                </td>
+                                                <td className="whitespace-nowrap">
+                                                    <code className="text-blue-600 font-mono text-xs">
                                                         {tx.item_code || '-'}
                                                     </code>
                                                 </td>
-                                                <td>{tx.item_name || '-'}</td>
-                                                <td>{tx.location_name || '-'}</td>
-                                                <td>
+                                                <td className="max-w-[12rem]">
+                                                    <span className="block truncate" title={tx.item_name || '-'}>
+                                                        {tx.item_name || '-'}
+                                                    </span>
+                                                </td>
+                                                <td className="max-w-[10rem]">
+                                                    <span className="block truncate" title={tx.location_name || '-'}>
+                                                        {tx.location_name || '-'}
+                                                    </span>
+                                                </td>
+                                                <td className="text-center">
                                                     <Badge variant={getTxBadge(tx.tx_type)}>
                                                         {tx.tx_type}
                                                     </Badge>
                                                 </td>
-                                                <td>{Number(tx.qty).toFixed(1)}</td>
-                                                <td>
+                                                <td className="whitespace-nowrap text-right">{Number(tx.qty).toFixed(1)}</td>
+                                                <td className="whitespace-nowrap text-right">
                                                     {tx.qty_on_hand !== null && tx.qty_on_hand !== undefined
                                                         ? Number(tx.qty_on_hand).toFixed(1)
                                                         : '-'}
                                                 </td>
-                                                <td>{tx.ref || '-'}</td>
-                                                <td className="text-sm text-gray-600">
-                                                    <span className="block max-w-xs truncate">{tx.note || '-'}</span>
+                                                <td className="hidden xl:table-cell max-w-[8rem]">
+                                                    <span className="block truncate" title={tx.ref || '-'}>
+                                                        {tx.ref || '-'}
+                                                    </span>
                                                 </td>
-                                                <td>
+                                                <td className="max-w-[8rem]">
+                                                    <span className="block truncate" title={tx.owner_name || '-'}>
+                                                        {tx.owner_name || '-'}
+                                                    </span>
+                                                </td>
+                                                <td className="hidden 2xl:table-cell text-sm text-gray-600 max-w-[12rem]">
+                                                    <span className="block truncate" title={tx.note || '-'}>
+                                                        {tx.note || '-'}
+                                                    </span>
+                                                </td>
+                                                <td className="text-center">
                                                     {(currentUser?.role === 'ADMIN' || currentUser?.role === 'STAFF') && (
-                                                        <div className="flex gap-2">
+                                                        <div className="flex items-center justify-center gap-1">
                                                             <Button
                                                                 variant="outline-primary"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Edit transaction"
                                                                 onClick={() => navigate(`/transactions/${tx.id}/edit`)}
                                                             >
-                                                                <Pencil className="w-4 h-4 mr-1" />
-                                                                Edit
+                                                                <Pencil className="w-4 h-4" />
                                                             </Button>
                                                             <Button
                                                                 variant="outline-danger"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Delete transaction"
                                                                 onClick={() => handleDelete(tx.id)}
                                                             >
-                                                                <Trash2 className="w-4 h-4 mr-1" />
-                                                                Delete
+                                                                <Trash2 className="w-4 h-4" />
                                                             </Button>
                                                         </div>
                                                     )}

--- a/front-end/src/components/UnitPage.tsx
+++ b/front-end/src/components/UnitPage.tsx
@@ -332,7 +332,7 @@ function UnitPage() {
                                             >
                                                 Multiplier {getSortIndicator('multiplier')}
                                             </th>
-                                            <th className="w-56">Actions</th>
+                                            <th className="w-24 text-center">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -348,24 +348,28 @@ function UnitPage() {
                                                     <code className="text-gray-600 font-mono">{unit.symbol}</code>
                                                 </td>
                                                 <td>{unit.multiplier}</td>
-                                                <td>
+                                                <td className="text-center">
                                                     {currentUser?.role === 'ADMIN' && (
-                                                        <div className="flex gap-2">
+                                                        <div className="flex items-center justify-center gap-1">
                                                             <Button
                                                                 variant="outline-primary"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Edit unit"
+                                                                aria-label="Edit unit"
                                                                 onClick={() => handleOpenModal(unit)}
                                                             >
-                                                                <Pencil className="w-4 h-4 mr-1" />
-                                                                Edit
+                                                                <Pencil className="w-4 h-4" />
                                                             </Button>
                                                             <Button
                                                                 variant="outline-danger"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Delete unit"
+                                                                aria-label="Delete unit"
                                                                 onClick={() => handleDelete(unit.id)}
                                                             >
-                                                                <Trash2 className="w-4 h-4 mr-1" />
-                                                                Delete
+                                                                <Trash2 className="w-4 h-4" />
                                                             </Button>
                                                         </div>
                                                     )}

--- a/front-end/src/components/UsersPage.tsx
+++ b/front-end/src/components/UsersPage.tsx
@@ -322,7 +322,7 @@ function UsersPage() {
                                             >
                                                 Created At {getSortIndicator('created_at')}
                                             </th>
-                                            <th className="w-48">Actions</th>
+                                            <th className="w-24 text-center">Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -350,24 +350,28 @@ function UsersPage() {
                                                 <td>
                                                     {new Date(user.created_at).toLocaleDateString()}
                                                 </td>
-                                                <td onClick={(e) => e.stopPropagation()}>
+                                                <td onClick={(e) => e.stopPropagation()} className="text-center">
                                                     {currentUser?.role === 'ADMIN' && (
-                                                        <div className="flex gap-2">
+                                                        <div className="flex items-center justify-center gap-1">
                                                             <Button
                                                                 variant="outline-primary"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Edit user"
+                                                                aria-label="Edit user"
                                                                 onClick={() => navigate(`/users/${user.id}/edit`)}
                                                             >
-                                                                <Pencil className="w-4 h-4 mr-1" />
-                                                                Edit
+                                                                <Pencil className="w-4 h-4" />
                                                             </Button>
                                                             <Button
                                                                 variant="outline-danger"
                                                                 size="sm"
+                                                                className="px-2"
+                                                                title="Delete user"
+                                                                aria-label="Delete user"
                                                                 onClick={() => handleDeleteUser(user.id)}
                                                             >
-                                                                <Trash2 className="w-4 h-4 mr-1" />
-                                                                Delete
+                                                                <Trash2 className="w-4 h-4" />
                                                             </Button>
                                                         </div>
                                                     )}


### PR DESCRIPTION
This pull request introduces significant improvements to authorization and ownership handling for stock transactions, especially for users with the STAFF role. It enforces that STAFF users can only access and modify transactions related to their own items, ensures owner user validation, and propagates ownership changes throughout the transaction lifecycle. Additionally, the repository and service layers have been updated to support these new checks and data flows. Some ToDo documentation items were also updated to reflect recent progress.

**Authorization and Ownership Enforcement:**

* Added STAFF-only scoping and ownership checks to all transaction-related operations in `StockService`, including helper methods for asserting access and resolving/validating owner users. STAFF users can now only access and mutate transactions for items they own. [[1]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4L1-R115) [[2]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4L80-R174) [[3]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4L130-R235)
* Updated all transaction endpoints in `stock_tx_route.py` to pass the current user to service methods, ensuring authorization logic is consistently applied. [[1]](diffhunk://#diff-53156f73cea450c433bfbdd61e611d02d7068c315ef26d1f515fe5916704800fL31-R32) [[2]](diffhunk://#diff-53156f73cea450c433bfbdd61e611d02d7068c315ef26d1f515fe5916704800fL45-R46) [[3]](diffhunk://#diff-53156f73cea450c433bfbdd61e611d02d7068c315ef26d1f515fe5916704800fL82-R83) [[4]](diffhunk://#diff-53156f73cea450c433bfbdd61e611d02d7068c315ef26d1f515fe5916704800fL96-R97) [[5]](diffhunk://#diff-53156f73cea450c433bfbdd61e611d02d7068c315ef26d1f515fe5916704800fL109-R110)

**Repository Layer Enhancements:**

* Modified `StockTxRepository` methods (`get_by_id`, `list_transactions`, `count_transactions`) to support scoping by owner user ID, including SQL changes to filter by item ownership and return owner names. [[1]](diffhunk://#diff-f761bfa30c2a81558b2d619585f1711b17dfe6abae8c87f411b1374c24665a84R12-R36) [[2]](diffhunk://#diff-f761bfa30c2a81558b2d619585f1711b17dfe6abae8c87f411b1374c24665a84L27-R68) [[3]](diffhunk://#diff-f761bfa30c2a81558b2d619585f1711b17dfe6abae8c87f411b1374c24665a84L59-R80) [[4]](diffhunk://#diff-f761bfa30c2a81558b2d619585f1711b17dfe6abae8c87f411b1374c24665a84R95-R106) [[5]](diffhunk://#diff-f761bfa30c2a81558b2d619585f1711b17dfe6abae8c87f411b1374c24665a84R133-R140) [[6]](diffhunk://#diff-f761bfa30c2a81558b2d619585f1711b17dfe6abae8c87f411b1374c24665a84L131-R168) [[7]](diffhunk://#diff-f761bfa30c2a81558b2d619585f1711b17dfe6abae8c87f411b1374c24665a84R183-R194)
* Updated the transaction update logic to allow updating the `user_id` field and propagate ownership changes to the `items` table. [[1]](diffhunk://#diff-f761bfa30c2a81558b2d619585f1711b17dfe6abae8c87f411b1374c24665a84R266-R268) [[2]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4R186) [[3]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4R257-R262) [[4]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4R272)

**Service Layer Data Flow:**

* All transaction creation and update operations now resolve, validate, and set the owner user ID, ensuring the correct user is associated with both the transaction and the item. [[1]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4L80-R174) [[2]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4R186) [[3]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4L118-R200) [[4]](diffhunk://#diff-bfff15dca1d0640261b6445e109d9975cb3a3507d9b3f06669d9fd20e429c5e4L130-R235)

**Documentation Updates:**

* Updated `ToDo.md` to mark CORS and frontend cleanup tasks as completed. [[1]](diffhunk://#diff-63e36571da69ac748ef8670cd90942045e5ff220a3607f265d1a4ffeeca7d15bL23-R23) [[2]](diffhunk://#diff-63e36571da69ac748ef8670cd90942045e5ff220a3607f265d1a4ffeeca7d15bL138-R142)