### PR TITLE
fix(frontend): add browser security headers

### DIFF
--- a/front-end/nginx.conf
+++ b/front-end/nginx.conf
@@ -8,6 +8,11 @@ server {
 
   client_max_body_size 20m;
 
+  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "no-referrer" always;
+  add_header Permissions-Policy "camera=(self), microphone=(), geolocation=()" always;
+
   location / {
     try_files $uri /index.html;
   }


### PR DESCRIPTION
## Summary
- Add a conservative Content-Security-Policy to the frontend Nginx config.
- Add X-Content-Type-Options, Referrer-Policy, and Permissions-Policy headers.
- Keep camera available for same-origin scanner flows while disabling microphone and geolocation.

## Context
This is a small hardening slice related to #41. It does not replace the larger fix of moving bearer tokens out of localStorage into HttpOnly/Secure/SameSite cookie-based session handling. It reduces the browser attack surface while that auth-storage migration is planned.

The CSP assumes the Docker deployment serves the frontend and API same-origin via /api. If another deployment calls a different API origin or adds third-party scripts, connect-src/script-src will need an explicit allowlist update.

## Validation
- PASS: npm ci
- PASS: npm run build
- PASS: git diff --check
- NOT RUN: nginx -t via Docker image; local Docker daemon was unavailable in my environment.
- PRE-EXISTING: npm run lint currently fails on unrelated no-explicit-any/no-unused-vars/react-hooks/react-refresh issues in existing frontend files.
- PRE-EXISTING: npm audit --audit-level=critical --omit=dev reports existing dependency advisories.
